### PR TITLE
Add config to minimize gas over estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ All files within this repository are licensed under the [GNU Affero General Publ
 ## Contributing
 
 ```sh
+# Run relayer with voidsigner feature to test configs locally
+yarn relay --wallet void --address <ADDRESS>
+
 # run test suite
 yarn test
 

--- a/scripts/runMainnet.sh
+++ b/scripts/runMainnet.sh
@@ -48,6 +48,7 @@ echo "MIN_RELAYER_FEE_PCT=0.0001" >> ${app_dir}/.env
 
 # Fee settings
 echo "PRIORITY_FEE_SCALER_1=0.8"  >> ${app_dir}/.env
+echo "RELAYER_GAS_PADDING=0"  >> ${app_dir}/.env
 
 # Redis settings
 echo "REDIS_URL='redis://127.0.0.1:6379'" >> ${app_dir}/.env


### PR DESCRIPTION
### Description

Currently, relayer over estimates gas which results in unprofitable fills

- Add config to minimize gas over-estimation
- Update readme to add step for running relayer with void signature to test config locally

