### PR TITLE
Execute installDependencies script as a root

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -6,6 +6,7 @@ files:
 hooks:
   AfterInstall:
     - location: scripts/installDependencies.sh
+      runas: root
     - location: scripts/installApplication.sh
       runas: root
   ApplicationStart:


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-944.

### How was it solved?

Script `installDependencies.sh` will be executed as root when deploying on AWS.
