### PR TITLE
Fix default node version issue

### DIFF
--- a/scripts/installApplication.sh
+++ b/scripts/installApplication.sh
@@ -4,5 +4,7 @@
 app_dir_name=/home/ubuntu/lisk-across-relayer
 cd $app_dir_name
 echo "Current DIR: $PWD"
+
+nvm use
 yarn install --frozen-lockfile
 yarn build

--- a/scripts/installDependencies.sh
+++ b/scripts/installDependencies.sh
@@ -36,6 +36,7 @@ install_node_version() {
 
     echo "Installing Node version $node_version..."
     nvm install $node_version
+    nvm alias default $node_version
 }
 
 install_node_version


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-944.

### How was it solved?

Alias for default node.js version was created.
This version is later used inside `installApplication.sh` script.