### PR TITLE
Update relayer inventory config to allow all LSK on Lisk

### DIFF
--- a/config/mainnet/relayerExternalInventory.json
+++ b/config/mainnet/relayerExternalInventory.json
@@ -27,7 +27,7 @@
       "1135": {
         "targetPct": 10,
         "thresholdPct": 1,
-        "targetOverageBuffer": 9
+        "targetOverageBuffer": 10
       }
     },
     "USDT": {


### PR DESCRIPTION
### What was the problem?

This PR resolves [LISK-1034](https://onchaincollective.atlassian.net/browse/LISK-1034)

### How was it solved?

- [x] Update relayer inventory config to allow 100% LSK on Lisk

### How was it tested?

NA


[LISK-1034]: https://onchaincollective.atlassian.net/browse/LISK-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ