### PR TITLE
Move Across Relayer secrets from AWS Secrets Manager to S3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # dotfiles are ignored by default and must be added explicitly. Use
 # `git add -f <dotfile>` add a dotfile. Only do this for public files.
-.env
+*.env*
 .secret
 
 node_modules
@@ -16,3 +16,6 @@ dist
 
 # Debugging files
 *.log
+
+# Exclude .env.example
+!.env.example

--- a/scripts/lisk/docker/dev/setEnvVariables.sh
+++ b/scripts/lisk/docker/dev/setEnvVariables.sh
@@ -4,9 +4,11 @@ set -eu
 echo "Setting environment variables within the current shell on the host"
 
 # Retreive env vars from S3 bucket and source them
-file_name=across-relayer-dev.env
-aws s3 cp s3://lisk-envs/$file_name .${file_name}
-source .${file_name}
-rm -f .${file_name}
+source_env_file_name=across-relayer-dev.env
+env_file_name=.${source_env_file_name}
+
+aws s3 cp s3://lisk-envs/$source_env_file_name ${env_file_name}
+source ${env_file_name}
+rm -f ${env_file_name}
 
 echo "Finished setting all the environment variables within the current shell on the host"

--- a/scripts/lisk/docker/dev/setEnvVariables.sh
+++ b/scripts/lisk/docker/dev/setEnvVariables.sh
@@ -1,29 +1,12 @@
 #!/bin/bash
 set -eu
 
-# Set env var from secrets
-# secret_id=arn:aws:secretsmanager:eu-west-3:132202091885:secret:mainnet/lisk-across-relayer/aws-CSi7ka
-secret_id=arn:aws:secretsmanager:eu-west-3:132202091885:secret:sepolia/across-relayer-dev/aws-7CIqpl
-RELAYER_CONFIG=`aws --region eu-west-3 secretsmanager get-secret-value --secret-id ${secret_id} | jq --raw-output .SecretString | jq -r .`
-
 echo "Setting environment variables within the current shell on the host"
 
-export AWS_REGION=`echo $RELAYER_CONFIG | jq -r ."AWS_REGION"`
-
-export AWS_ECR_REGISTRY=`echo $RELAYER_CONFIG | jq -r ."AWS_ECR_REGISTRY"`
-
-export AWS_ECR_REPOSITORY=`echo $RELAYER_CONFIG | jq -r ."AWS_ECR_REPOSITORY"`
-
-export ACROSS_RELAYER_IMAGE_TAG=`echo $RELAYER_CONFIG | jq -r ."ACROSS_RELAYER_IMAGE_TAG"`
-
-export NETWORK=`echo $RELAYER_CONFIG | jq -r ."NETWORK"`
-
-export RELAYER_1_API_SERVER_HOST=`echo $RELAYER_CONFIG | jq -r ."RELAYER_1_API_SERVER_HOST"`
-
-export REBALANCER_API_SERVER_HOST=`echo $RELAYER_CONFIG | jq -r ."REBALANCER_API_SERVER_HOST"`
-
-export RELAYER_1_API_SERVER_PORT=`echo $RELAYER_CONFIG | jq -r ."RELAYER_1_API_SERVER_PORT"`
-
-export REBALANCER_API_SERVER_PORT=`echo $RELAYER_CONFIG | jq -r ."REBALANCER_API_SERVER_PORT"`
+# Retreive env vars from S3 bucket and source them
+file_name=across-relayer-dev.env
+aws s3 cp s3://lisk-envs/$file_name .${file_name}
+source .${file_name}
+rm -f .${file_name}
 
 echo "Finished setting all the environment variables within the current shell on the host"

--- a/scripts/lisk/docker/setEnvVariables.sh
+++ b/scripts/lisk/docker/setEnvVariables.sh
@@ -4,9 +4,11 @@ set -eu
 echo "Setting environment variables within the current shell on the host"
 
 # Retreive env vars from S3 bucket and source them
-file_name=across-relayer-mainnet.env
-aws s3 cp s3://lisk-envs/$file_name .${file_name}
-source .${file_name}
-rm -f .${file_name}
+source_env_file_name=across-relayer-mainnet.env
+env_file_name=.${source_env_file_name}
+
+aws s3 cp s3://lisk-envs/$source_env_file_name ${env_file_name}
+source ${env_file_name}
+rm -f ${env_file_name}
 
 echo "Finished setting all the environment variables within the current shell on the host"

--- a/scripts/lisk/docker/setEnvVariables.sh
+++ b/scripts/lisk/docker/setEnvVariables.sh
@@ -1,29 +1,12 @@
 #!/bin/bash
 set -eu
 
-# Set env var from secrets
-secret_id=arn:aws:secretsmanager:eu-west-3:132202091885:secret:mainnet/lisk-across-relayer/aws-CSi7ka
-# secret_id=arn:aws:secretsmanager:eu-west-3:132202091885:secret:sepolia/across-relayer-dev/aws-7CIqpl
-RELAYER_CONFIG=`aws --region eu-west-3 secretsmanager get-secret-value --secret-id ${secret_id} | jq --raw-output .SecretString | jq -r .`
-
 echo "Setting environment variables within the current shell on the host"
 
-export AWS_REGION=`echo $RELAYER_CONFIG | jq -r ."AWS_REGION"`
-
-export AWS_ECR_REGISTRY=`echo $RELAYER_CONFIG | jq -r ."AWS_ECR_REGISTRY"`
-
-export AWS_ECR_REPOSITORY=`echo $RELAYER_CONFIG | jq -r ."AWS_ECR_REPOSITORY"`
-
-export ACROSS_RELAYER_IMAGE_TAG=`echo $RELAYER_CONFIG | jq -r ."ACROSS_RELAYER_IMAGE_TAG"`
-
-export NETWORK=`echo $RELAYER_CONFIG | jq -r ."NETWORK"`
-
-export RELAYER_1_API_SERVER_HOST=`echo $RELAYER_CONFIG | jq -r ."RELAYER_1_API_SERVER_HOST"`
-
-export REBALANCER_API_SERVER_HOST=`echo $RELAYER_CONFIG | jq -r ."REBALANCER_API_SERVER_HOST"`
-
-export RELAYER_1_API_SERVER_PORT=`echo $RELAYER_CONFIG | jq -r ."RELAYER_1_API_SERVER_PORT"`
-
-export REBALANCER_API_SERVER_PORT=`echo $RELAYER_CONFIG | jq -r ."REBALANCER_API_SERVER_PORT"`
+# Retreive env vars from S3 bucket and source them
+file_name=across-relayer-mainnet.env
+aws s3 cp s3://lisk-envs/$file_name .${file_name}
+source .${file_name}
+rm -f .${file_name}
 
 echo "Finished setting all the environment variables within the current shell on the host"


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1148.

### How was it solved?

- [x] Environment files for mainnet and testnet were created inside S3 bucket
- [x] Scripts were modified to pull data from S3 instead of AWS Secrets

### How was it tested?

Start the containers locally with the docker dev scripts
Run: `curl --fail http://localhost:3000/healthz` and check container health with `docker ps`
