### PR TITLE
Update fork-sync.yaml

### DIFF
--- a/.github/workflows/fork-sync.yaml
+++ b/.github/workflows/fork-sync.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    timeout-minutes: 45 # `yarn test` takes longer time
+    timeout-minutes: 60 # `yarn test` takes longer time
     steps:
       - uses: tgymnich/fork-sync@v2.0.10
         with:


### PR DESCRIPTION
Increase fork sync workflow timeout.
The last run had timed out: https://github.com/LiskHQ/across-relayer/actions/runs/13247246243