### PR TITLE
Update relayer config

### DIFF
--- a/config/mainnet/relayerExternalInventory.json
+++ b/config/mainnet/relayerExternalInventory.json
@@ -18,16 +18,18 @@
       "1135": {
         "targetPct": 30,
         "thresholdPct": 10,
-        "targetOverageBuffer": 3,
+        "targetOverageBuffer": 1.8,
         "unwrapWethThreshold": 0.025,
-        "unwrapWethTarget": 0.1
+        "unwrapWethTarget": 0.1,
+        "withdrawExcessPeriod": 129600
       }
     },
     "LSK": {
       "1135": {
         "targetPct": 30,
         "thresholdPct": 20,
-        "targetOverageBuffer": 3
+        "targetOverageBuffer": 1.8,
+        "withdrawExcessPeriod": 129600
       }
     }
   }

--- a/config/sepolia/relayerExternalInventory.json
+++ b/config/sepolia/relayerExternalInventory.json
@@ -18,9 +18,10 @@
       "4202": {
         "targetPct": 30,
         "thresholdPct": 10,
-        "targetOverageBuffer": 1.5,
+        "targetOverageBuffer": 1.8,
         "unwrapWethThreshold": 0.025,
-        "unwrapWethTarget": 0.1
+        "unwrapWethTarget": 0.1,
+        "withdrawExcessPeriod": 129600
       }
     }
   }


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1905

### How was it solved?

- Update relayer config to enable auto-rebalancing
  - Rebalancing is performed atleast every 1.5 days (129600 secs)
  - targetOverageBuffer is set to 1.8

### How was it tested?

- Locally with dev scripts
- Auto-rebalancing analysis attached to LISK-1904
